### PR TITLE
Fix UDP listener crash on malformed packets

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -252,6 +252,10 @@ func startUDPListener(ctx context.Context, wg *sync.WaitGroup, errCh chan<- erro
 			}
 			payload := string(buf[:n])
 			body := strings.SplitN(payload, "\n", 2)
+			if len(body) < 2 {
+				slog.Warn("udp listener invalid payload", slog.String("payload", payload))
+				continue
+			}
 			msg := UdpMessage{
 				Topic:   body[0],
 				Payload: body[1],


### PR DESCRIPTION
## Summary
- handle invalid UDP payloads without crashing

## Testing
- `go vet ./...` *(fails: unable to fetch modules)*
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_687aca3afcb88320911b847527b6bf2b