### PR TITLE
Update initConfig defaults

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,8 +60,8 @@ func initConfig() {
 	viper.SetDefault("HTTP.listen", "127.0.0.1:8080")
 	viper.SetDefault("HTTP.root", "dist")
 	viper.SetDefault("MQTT.tcp", "127.0.0.1:1883")
-	viper.SetDefault("MQTT.websocket", "127.0.0.1:6565")
-	viper.SetDefault("UDP.listen", "127.0.0.1:5656")
+	viper.SetDefault("MQTT.websocket", "127.0.0.1:9090")
+	viper.SetDefault("UDP.listen", "127.0.0.1:6565")
 	if cfgFile != "" {
 		// フラグで指定された設定ファイルを使用します。
 		viper.SetConfigFile(cfgFile)


### PR DESCRIPTION
## Summary
- set default MQTT websocket address to `127.0.0.1:9090`
- set default UDP listen address to `127.0.0.1:6565`

## Testing
- `go test ./...` *(fails: unable to download modules)*
- `go vet ./...` *(fails: unable to download modules)*
- `go build ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_687acd712ebc8320a31b9a97f096557a