### PR TITLE
cmd: run サブコマンド追加と純粋関数抽出によるテスト整備

### DIFF
--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -63,6 +63,36 @@ type mqttAuthConfig struct {
 	Users []mqttUser `mapstructure:"users"`
 }
 
+// matchPasswordCredential は users に同一の username/password 組が存在するか判定する。
+// 完全一致のみ true を返す。空ユーザリストや不一致では false。
+func matchPasswordCredential(users []mqttUser, username, password string) bool {
+	for _, u := range users {
+		if u.Username == username && u.Password == password {
+			return true
+		}
+	}
+	return false
+}
+
+// encodeUdpMessage は MQTT トピック名と payload を "<topic>\n<payload>" の UDP 転送フォーマットに整形する。
+// parseUdpMessage と対称な関係にあるが、topic に "\n" が含まれる場合は parseUdpMessage で復元できない点に注意。
+func encodeUdpMessage(topic string, payload []byte) []byte {
+	return bytes.Join([][]byte{[]byte(topic), payload}, []byte("\n"))
+}
+
+// buildTopicToAddressMap は "アドレス → トピックリスト" の forwards 設定を
+// "トピック → アドレス" の逆引きマップに変換する。
+// 同一トピックが複数アドレスに登録されている場合、後勝ちで上書きされる。
+func buildTopicToAddressMap(forwards map[string][]string) map[string]string {
+	topics := map[string]string{}
+	for addr, tpcs := range forwards {
+		for _, topic := range tpcs {
+			topics[topic] = addr
+		}
+	}
+	return topics
+}
+
 type mqttAuthHook struct {
 	mqtt.HookBase
 	cfg mqttAuthConfig
@@ -80,11 +110,8 @@ func (h *mqttAuthHook) Provides(b byte) bool {
 func (h *mqttAuthHook) OnConnectAuthenticate(cl *mqtt.Client, pk packets.Packet) bool {
 	switch h.cfg.Mode {
 	case "password":
-		for _, u := range h.cfg.Users {
-			if u.Username == string(pk.Connect.Username) &&
-				u.Password == string(pk.Connect.Password) {
-				return true
-			}
+		if matchPasswordCredential(h.cfg.Users, string(pk.Connect.Username), string(pk.Connect.Password)) {
+			return true
 		}
 		slog.Warn("mqtt auth rejected", slog.String("username", string(pk.Connect.Username)))
 		return false
@@ -164,13 +191,10 @@ func startMQTTBroker(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error
 
 	// 転送用UDPの設定を取得
 	forwards := viper.GetStringMapStringSlice("UDP.forwards")
-	topics := map[string]string{}
 	for addr, tpcs := range forwards {
 		slog.Info("load configuration", slog.String("UDP.forwards.topic", addr), slog.String("UDP.forwards.address", strings.Join(tpcs, ",")))
-		for _, topic := range tpcs {
-			topics[topic] = addr
-		}
 	}
+	topics := buildTopicToAddressMap(forwards)
 	hasTopic := len(forwards) > 0 // トピック設定があるかの判定用
 
 	callbackFn := func(cl *mqtt.Client, sub packets.Subscription, pk packets.Packet) {
@@ -188,11 +212,7 @@ func startMQTTBroker(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error
 			if udpAddr, err := net.ResolveUDPAddr("udp", writeTo); err != nil {
 				slog.Error("udp forwarder failed to resolve addres", slog.String("error", err.Error()), slog.String("writeTo", writeTo))
 			} else {
-				// 送信用メッセージを作成
-				messages := [][]byte{}
-				messages = append(messages, []byte(pk.TopicName))
-				messages = append(messages, pk.Payload)
-				body := bytes.Join(messages, []byte("\n"))
+				body := encodeUdpMessage(pk.TopicName, pk.Payload)
 
 				// アドレスに以上がなければ、送信時のエラーチェックしない
 				if n, err := conn.WriteToUDP(body, udpAddr); err != nil {

--- a/cmd/mqtt_test.go
+++ b/cmd/mqtt_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMqttTopicMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		topic  string
+		want   bool
+	}{
+		// 完全一致
+		{name: "exact single level", filter: "foo", topic: "foo", want: true},
+		{name: "exact multi level", filter: "a/b/c", topic: "a/b/c", want: true},
+		{name: "case sensitive mismatch", filter: "Foo", topic: "foo", want: false},
+
+		// レベル数の不一致
+		{name: "filter has fewer levels", filter: "a/b", topic: "a/b/c", want: false},
+		{name: "filter has more levels", filter: "a/b/c", topic: "a/b", want: false},
+		{name: "first segment differs", filter: "a/b", topic: "x/b", want: false},
+		{name: "middle segment differs", filter: "a/b/c", topic: "a/x/c", want: false},
+
+		// + (単一レベルワイルドカード)
+		{name: "+ matches single level middle", filter: "a/+/c", topic: "a/b/c", want: true},
+		{name: "+ matches single level head", filter: "+/b", topic: "a/b", want: true},
+		{name: "+ matches single level tail", filter: "a/+", topic: "a/b", want: true},
+		{name: "+ does not match multiple levels", filter: "a/+", topic: "a/b/c", want: false},
+		{name: "+ does not match missing level", filter: "a/+", topic: "a", want: false},
+		{name: "multiple + match", filter: "+/+/+", topic: "x/y/z", want: true},
+		{name: "multiple + with literal", filter: "+/b/+", topic: "a/b/c", want: true},
+		{name: "+ does not match literal mismatch", filter: "+/b", topic: "a/c", want: false},
+
+		// # (マルチレベルワイルドカード)
+		{name: "# alone matches single", filter: "#", topic: "a", want: true},
+		{name: "# alone matches multi", filter: "#", topic: "a/b/c", want: true},
+		{name: "trailing # matches deeper", filter: "a/#", topic: "a/b/c", want: true},
+		{name: "trailing # matches one level", filter: "a/#", topic: "a/b", want: true},
+		{name: "trailing # matches parent itself", filter: "a/#", topic: "a", want: true},
+		{name: "trailing # mismatch on prefix", filter: "a/#", topic: "x/b", want: false},
+
+		// + と # の混在
+		{name: "+ and # combined", filter: "a/+/#", topic: "a/b/c/d", want: true},
+		{name: "+ and # combined parent only", filter: "a/+/#", topic: "a/b", want: true},
+		{name: "+ and # combined missing wildcard level", filter: "a/+/#", topic: "a", want: false},
+
+		// エッジケース
+		{name: "empty filter and empty topic", filter: "", topic: "", want: true},
+		{name: "empty filter vs non-empty", filter: "", topic: "a", want: false},
+		{name: "non-empty filter vs empty topic", filter: "a", topic: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mqttTopicMatch(tt.filter, tt.topic)
+			assert.Equalf(t, tt.want, got, "mqttTopicMatch(%q, %q)", tt.filter, tt.topic)
+		})
+	}
+}
+
+func TestMatchPasswordCredential(t *testing.T) {
+	users := []mqttUser{
+		{Username: "alice", Password: "alice-pw"},
+		{Username: "bob", Password: "bob-pw"},
+	}
+
+	tests := []struct {
+		name     string
+		users    []mqttUser
+		username string
+		password string
+		want     bool
+	}{
+		{name: "exact match first", users: users, username: "alice", password: "alice-pw", want: true},
+		{name: "exact match second", users: users, username: "bob", password: "bob-pw", want: true},
+		{name: "username matches but wrong password", users: users, username: "alice", password: "bob-pw", want: false},
+		{name: "password matches but wrong username", users: users, username: "carol", password: "alice-pw", want: false},
+		{name: "unknown user", users: users, username: "carol", password: "carol-pw", want: false},
+		{name: "case sensitive username", users: users, username: "Alice", password: "alice-pw", want: false},
+		{name: "case sensitive password", users: users, username: "alice", password: "Alice-PW", want: false},
+		{name: "empty users list", users: nil, username: "alice", password: "alice-pw", want: false},
+		{name: "empty credentials against populated users", users: users, username: "", password: "", want: false},
+		{name: "empty credentials match empty entry", users: []mqttUser{{Username: "", Password: ""}}, username: "", password: "", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPasswordCredential(tt.users, tt.username, tt.password)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEncodeUdpMessage(t *testing.T) {
+	t.Run("encode then parse round-trip", func(t *testing.T) {
+		topic := "sensor/temp"
+		payload := []byte("23.5")
+
+		encoded := encodeUdpMessage(topic, payload)
+		assert.Equal(t, []byte("sensor/temp\n23.5"), encoded)
+
+		msg, ok := parseUdpMessage(encoded)
+		require.True(t, ok)
+		assert.Equal(t, topic, msg.Topic)
+		assert.Equal(t, string(payload), msg.Payload)
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		encoded := encodeUdpMessage("topic", []byte{})
+		assert.Equal(t, []byte("topic\n"), encoded)
+
+		msg, ok := parseUdpMessage(encoded)
+		require.True(t, ok)
+		assert.Equal(t, "topic", msg.Topic)
+		assert.Equal(t, "", msg.Payload)
+	})
+
+	t.Run("nil payload", func(t *testing.T) {
+		encoded := encodeUdpMessage("topic", nil)
+		assert.Equal(t, []byte("topic\n"), encoded)
+	})
+
+	t.Run("binary payload preserved", func(t *testing.T) {
+		payload := []byte{0x00, 0x01, 0xff, 0xfe}
+		encoded := encodeUdpMessage("topic", payload)
+		assert.Equal(t, append([]byte("topic\n"), payload...), encoded)
+
+		msg, ok := parseUdpMessage(encoded)
+		require.True(t, ok)
+		assert.Equal(t, "topic", msg.Topic)
+		assert.Equal(t, string(payload), msg.Payload)
+	})
+
+	t.Run("payload containing newlines round-trips because parser splits only at first newline", func(t *testing.T) {
+		payload := []byte("line1\nline2")
+		encoded := encodeUdpMessage("topic", payload)
+
+		msg, ok := parseUdpMessage(encoded)
+		require.True(t, ok)
+		assert.Equal(t, "topic", msg.Topic)
+		assert.Equal(t, string(payload), msg.Payload)
+	})
+
+	t.Run("topic with newline breaks round-trip (documented quirk)", func(t *testing.T) {
+		// topic 内に "\n" を含むと parseUdpMessage は最初の "\n" で切るため、
+		// topic の後半は payload 側に取り込まれて復元できない。
+		encoded := encodeUdpMessage("a\nb", []byte("c"))
+		assert.Equal(t, []byte("a\nb\nc"), encoded)
+
+		msg, ok := parseUdpMessage(encoded)
+		require.True(t, ok)
+		assert.Equal(t, "a", msg.Topic)
+		assert.Equal(t, "b\nc", msg.Payload)
+	})
+}
+
+func TestBuildTopicToAddressMap(t *testing.T) {
+	t.Run("single address single topic", func(t *testing.T) {
+		got := buildTopicToAddressMap(map[string][]string{
+			"127.0.0.1:6000": {"sensor/temp"},
+		})
+		assert.Equal(t, map[string]string{"sensor/temp": "127.0.0.1:6000"}, got)
+	})
+
+	t.Run("single address multiple topics", func(t *testing.T) {
+		got := buildTopicToAddressMap(map[string][]string{
+			"127.0.0.1:6000": {"sensor/temp", "sensor/humidity"},
+		})
+		assert.Equal(t, map[string]string{
+			"sensor/temp":     "127.0.0.1:6000",
+			"sensor/humidity": "127.0.0.1:6000",
+		}, got)
+	})
+
+	t.Run("multiple addresses different topics", func(t *testing.T) {
+		got := buildTopicToAddressMap(map[string][]string{
+			"127.0.0.1:6000": {"sensor/temp"},
+			"127.0.0.1:6001": {"sensor/humidity"},
+		})
+		assert.Equal(t, map[string]string{
+			"sensor/temp":     "127.0.0.1:6000",
+			"sensor/humidity": "127.0.0.1:6001",
+		}, got)
+	})
+
+	t.Run("empty input returns empty map (not nil)", func(t *testing.T) {
+		got := buildTopicToAddressMap(map[string][]string{})
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("nil input returns empty map", func(t *testing.T) {
+		got := buildTopicToAddressMap(nil)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty topic list under address is skipped", func(t *testing.T) {
+		got := buildTopicToAddressMap(map[string][]string{
+			"127.0.0.1:6000": {},
+		})
+		assert.Empty(t, got)
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,9 +34,6 @@ var rootCmd = &cobra.Command{
 	Long: `本サービスは、HTTPサーバとMQTTブローカー機能を提供します。
 MQTTは、UDP通信を中継することができ、指定ポートにUDPでメッセージを送付すると、MQTTによってPublishされます。
 一方、設定ファイルで指定したトピック情報は、UDPとして送信されます。`,
-	Run: func(cmd *cobra.Command, args []string) {
-		execute()
-	},
 }
 
 // Execute はすべての子コマンドを root コマンドに追加し、フラグを適切に設定します。

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// runCmdは、HTTP/MQTT/UDP の各サービスを起動するコマンドを表します。
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "HTTP/MQTT/UDP の各サービスを起動します",
+	Long: `本サービスは、HTTPサーバとMQTTブローカー機能を提供します。
+MQTTは、UDP通信を中継することができ、指定ポートにUDPでメッセージを送付すると、MQTTによってPublishされます。
+一方、設定ファイルで指定したトピック情報は、UDPとして送信されます。`,
+	Run: func(cmd *cobra.Command, args []string) {
+		execute()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}

--- a/cmd/udp.go
+++ b/cmd/udp.go
@@ -32,23 +32,41 @@ type UdpMessage struct {
 	Payload string
 }
 
+// parseUdpMessage は "<topic>\n<payload>" 形式の UDP ペイロードを分解する。
+// トピックが空、または改行が無い場合は ok=false を返す。
+func parseUdpMessage(buf []byte) (UdpMessage, bool) {
+	body := strings.SplitN(string(buf), "\n", 2)
+	if len(body) < 2 || body[0] == "" {
+		return UdpMessage{}, false
+	}
+	return UdpMessage{Topic: body[0], Payload: body[1]}, true
+}
+
+// resolveUdpListenAddr は "host:port" 形式の文字列から *net.UDPAddr を生成する。
+// host が IP リテラルでない場合 IP は nil となり、ListenUDP では全インタフェースで待ち受けとなる。
+func resolveUdpListenAddr(addr string) (*net.UDPAddr, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	return &net.UDPAddr{IP: net.ParseIP(host), Port: port}, nil
+}
+
 // UDPリスナーを起動し、エラー発生時に errCh へ通知、コンテキストキャンセルで停止
 func startUDPListener(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error, msgCh chan<- UdpMessage) {
 	defer wg.Done()
 	updListen := viper.GetString("UDP.listen")
 	slog.Info("load configuration", slog.String("UDP.listen", updListen))
-	udpAddr, udpPort, err := net.SplitHostPort(updListen)
+	addr, err := resolveUdpListenAddr(updListen)
 	if err != nil {
 		errCh <- err
 		return
 	}
-	port, err := strconv.Atoi(udpPort)
-	if err != nil {
-		errCh <- err
-		return
-	}
-	addr := net.UDPAddr{IP: net.ParseIP(udpAddr), Port: port}
-	conn, err := net.ListenUDP("udp", &addr)
+	conn, err := net.ListenUDP("udp", addr)
 	if err != nil {
 		errCh <- err
 		return
@@ -72,15 +90,10 @@ func startUDPListener(ctx context.Context, wg *sync.WaitGroup, errCh chan<- erro
 				errCh <- err
 				return
 			}
-			payload := string(buf[:n])
-			body := strings.SplitN(payload, "\n", 2)
-			if len(body) < 2 || body[0] == "" {
-				slog.Warn("udp listener invalid payload", slog.String("payload", payload))
+			msg, ok := parseUdpMessage(buf[:n])
+			if !ok {
+				slog.Warn("udp listener invalid payload", slog.String("payload", string(buf[:n])))
 				continue
-			}
-			msg := UdpMessage{
-				Topic:   body[0],
-				Payload: body[1],
 			}
 			msgCh <- msg
 		}

--- a/cmd/udp_test.go
+++ b/cmd/udp_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUdpMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		wantMsg UdpMessage
+		wantOk  bool
+	}{
+		{
+			name:    "valid topic and payload",
+			input:   []byte("sensor/temp\n23.5"),
+			wantMsg: UdpMessage{Topic: "sensor/temp", Payload: "23.5"},
+			wantOk:  true,
+		},
+		{
+			name:    "payload contains newlines preserved as-is",
+			input:   []byte("topic\nline1\nline2"),
+			wantMsg: UdpMessage{Topic: "topic", Payload: "line1\nline2"},
+			wantOk:  true,
+		},
+		{
+			name:    "empty payload after newline",
+			input:   []byte("topic\n"),
+			wantMsg: UdpMessage{Topic: "topic", Payload: ""},
+			wantOk:  true,
+		},
+		{
+			name:    "binary payload",
+			input:   append([]byte("topic\n"), 0x00, 0x01, 0xff, 0xfe),
+			wantMsg: UdpMessage{Topic: "topic", Payload: string([]byte{0x00, 0x01, 0xff, 0xfe})},
+			wantOk:  true,
+		},
+		{
+			name:    "single level topic",
+			input:   []byte("a\nb"),
+			wantMsg: UdpMessage{Topic: "a", Payload: "b"},
+			wantOk:  true,
+		},
+		{
+			name:    "multi-level topic",
+			input:   []byte("a/b/c/d\nx"),
+			wantMsg: UdpMessage{Topic: "a/b/c/d", Payload: "x"},
+			wantOk:  true,
+		},
+		{
+			name:    "no newline rejects",
+			input:   []byte("topiconly"),
+			wantMsg: UdpMessage{},
+			wantOk:  false,
+		},
+		{
+			name:    "empty topic rejects",
+			input:   []byte("\npayload"),
+			wantMsg: UdpMessage{},
+			wantOk:  false,
+		},
+		{
+			name:    "newline only rejects",
+			input:   []byte("\n"),
+			wantMsg: UdpMessage{},
+			wantOk:  false,
+		},
+		{
+			name:    "empty input rejects",
+			input:   []byte(""),
+			wantMsg: UdpMessage{},
+			wantOk:  false,
+		},
+		{
+			name:    "nil input rejects",
+			input:   nil,
+			wantMsg: UdpMessage{},
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMsg, gotOk := parseUdpMessage(tt.input)
+			require.Equal(t, tt.wantOk, gotOk, "ok flag mismatch")
+			assert.Equal(t, tt.wantMsg, gotMsg)
+		})
+	}
+}
+
+func TestResolveUdpListenAddr(t *testing.T) {
+	t.Run("valid IPv4 address", func(t *testing.T) {
+		got, err := resolveUdpListenAddr("127.0.0.1:6565")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.IP.Equal(net.ParseIP("127.0.0.1")))
+		assert.Equal(t, 6565, got.Port)
+	})
+
+	t.Run("valid IPv6 address", func(t *testing.T) {
+		got, err := resolveUdpListenAddr("[::1]:6565")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.IP.Equal(net.ParseIP("::1")))
+		assert.Equal(t, 6565, got.Port)
+	})
+
+	t.Run("zero IP wildcard", func(t *testing.T) {
+		got, err := resolveUdpListenAddr("0.0.0.0:6565")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.IP.Equal(net.IPv4zero))
+		assert.Equal(t, 6565, got.Port)
+	})
+
+	t.Run("port zero is allowed (ephemeral)", func(t *testing.T) {
+		got, err := resolveUdpListenAddr("127.0.0.1:0")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 0, got.Port)
+	})
+
+	t.Run("missing port returns error", func(t *testing.T) {
+		_, err := resolveUdpListenAddr("127.0.0.1")
+		require.Error(t, err)
+	})
+
+	t.Run("non-numeric port returns error", func(t *testing.T) {
+		_, err := resolveUdpListenAddr("127.0.0.1:abc")
+		require.Error(t, err)
+	})
+
+	t.Run("empty string returns error", func(t *testing.T) {
+		_, err := resolveUdpListenAddr("")
+		require.Error(t, err)
+	})
+
+	t.Run("hostname yields nil IP (documented quirk: listens on all interfaces)", func(t *testing.T) {
+		// net.ParseIP は IP リテラル以外を受け付けないため "localhost" は nil となる。
+		// その結果 net.ListenUDP は全インタフェースで待ち受けに格上げされる点に注意。
+		got, err := resolveUdpListenAddr("localhost:6565")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Nil(t, got.IP, "hostnames silently lose IP — surfaced for visibility")
+		assert.Equal(t, 6565, got.Port)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/mochi-mqtt/server/v2 v2.7.9
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
@@ -18,6 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -33,4 +36,5 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

- `driensten` の起動処理を `run` サブコマンドへ移行（cobra-cli で生成）。サブコマンド指定なしの場合はヘルプを表示。
- MQTT/UDP まわりの処理から副作用のないロジックを純粋関数として抽出し、testify ベースの単体テストを 68 ケース追加。

## 変更内容

### `run` サブコマンド追加
- `cobra-cli add run` でテンプレート生成。
- `cmd/root.go` の `Run` に直書きしていた起動処理を `cmd/run.go` の `runCmd.Run` へ移譲。
- `driensten run` で起動、`driensten` 単独はヘルプ表示に変更（既存の挙動から変更）。

### 純粋関数の抽出

| 抽出関数 | 元位置 | 用途 |
|---|---|---|
| `parseUdpMessage` | `cmd/udp.go` | `<topic>\n<payload>` 形式の UDP ペイロード分解（先行コミットで対応済みを含めテスト追加） |
| `encodeUdpMessage` | `cmd/mqtt.go` | parse の対称操作。MQTT→UDP 転送時のペイロード組み立て |
| `resolveUdpListenAddr` | `cmd/udp.go` | `host:port` 文字列を `*net.UDPAddr` に解決 |
| `matchPasswordCredential` | `cmd/mqtt.go` | MQTT パスワード認証のユーザ照合 |
| `buildTopicToAddressMap` | `cmd/mqtt.go` | forwards 設定（アドレス→トピックリスト）を逆引きマップへ変換 |
| `mqttTopicMatch` | `cmd/mqtt.go` | 既存関数。テストのみ追加 |

呼び出し側を 1 行〜数行に置き換えただけで、外部から見た挙動は等価。

### テスト整備
- `github.com/stretchr/testify` を依存に追加。
- テーブル駆動テストで合計 **68 ケース**（`mqttTopicMatch` 27 / `parseUdpMessage` 11 / `resolveUdpListenAddr` 8 / `matchPasswordCredential` 10 / `encodeUdpMessage` 6 / `buildTopicToAddressMap` 6）。
- `go test -race ./...` で全 PASS、`go vet` クリーン。

## レビューポイント

- `resolveUdpListenAddr` のテストで、`localhost` 等のホスト名を渡すと `net.ParseIP` が nil を返し、結果として全インタフェース待ち受けに格上げされるサイレントな挙動を**現状維持**のまま記録しています（既存挙動の変更を避けるため）。今後より厳格な検証に切り替えるかは別タスクとして扱う想定です。
- `encodeUdpMessage` のテストで topic に `\n` を含めると round-trip が壊れる挙動も同様に記録。
- 既存ファイルの中で `cmd/root.go` から `Run` フィールドを削除しています。`driensten` を引数なしで叩いていた利用箇所があれば挙動が変わります。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `driensten run` で従来どおりサービスが起動することを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)