### PR TITLE
cmd: 統合テスト Phase 2/3 を追加 (auth / forwarding / invalid payload / TLS)

### DIFF
--- a/cmd/integration_auth_test.go
+++ b/cmd/integration_auth_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startBrokerForTest は MQTT broker を起動するヘルパ。
+// 任意の追加 viper 設定を受け取り、起動完了を待ってから返る。
+// 戻り値の cleanup を defer で呼ぶこと。
+func startBrokerForTest(t *testing.T, mqttTCP string, configure func()) (errCh <-chan error, cleanup func()) {
+	t.Helper()
+
+	viper.Set("MQTT.tcp", mqttTCP)
+	viper.Set("MQTT.websocket", localAddr(freeTCPPort(t)))
+	if configure != nil {
+		configure()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	errChBuf := make(chan error, 2)
+	msgCh := make(chan UdpMessage, 1)
+
+	wg.Add(1)
+	go startMQTTBroker(ctx, &wg, errChBuf, msgCh)
+
+	waitForTCP(t, mqttTCP, 2*time.Second)
+
+	cleanup = func() {
+		cancel()
+		waitWG(t, &wg, 3*time.Second)
+	}
+	return errChBuf, cleanup
+}
+
+// pahoConnectExpectingSuccess は paho クライアントを接続し、成功することを assert する。
+func pahoConnectExpectingSuccess(t *testing.T, brokerAddr, clientID, username, password string) paho.Client {
+	t.Helper()
+	opts := paho.NewClientOptions().
+		AddBroker("tcp://" + brokerAddr).
+		SetClientID(clientID).
+		SetConnectTimeout(2 * time.Second).
+		SetAutoReconnect(false)
+	if username != "" || password != "" {
+		opts.SetUsername(username).SetPassword(password)
+	}
+	c := paho.NewClient(opts)
+	tok := c.Connect()
+	require.True(t, tok.WaitTimeout(3*time.Second), "MQTT connect timeout")
+	require.NoError(t, tok.Error(), "MQTT connect should succeed")
+	return c
+}
+
+// pahoConnectExpectingRejection は paho クライアントを接続し、認証拒否されることを assert する。
+func pahoConnectExpectingRejection(t *testing.T, brokerAddr, clientID, username, password string) {
+	t.Helper()
+	opts := paho.NewClientOptions().
+		AddBroker("tcp://" + brokerAddr).
+		SetClientID(clientID).
+		SetConnectTimeout(2 * time.Second).
+		SetAutoReconnect(false).
+		SetUsername(username).
+		SetPassword(password)
+	c := paho.NewClient(opts)
+	defer c.Disconnect(50)
+
+	tok := c.Connect()
+	require.True(t, tok.WaitTimeout(3*time.Second), "MQTT connect token did not complete")
+	require.Error(t, tok.Error(), "MQTT broker should have rejected credentials %q/%q", username, password)
+}
+
+// E: MQTT 認証
+//
+// none モードと password モードそれぞれで、正規/不正なクレデンシャルが
+// 期待どおり受理・拒否されることを確認する。
+func TestIntegration_MQTTAuth(t *testing.T) {
+	t.Run("none mode accepts no credentials", func(t *testing.T) {
+		resetViper(t)
+		mqttTCP := localAddr(freeTCPPort(t))
+		_, cleanup := startBrokerForTest(t, mqttTCP, func() {
+			viper.Set("MQTT.auth.mode", "none")
+		})
+		defer cleanup()
+
+		c := pahoConnectExpectingSuccess(t, mqttTCP, "auth-none-empty", "", "")
+		c.Disconnect(50)
+	})
+
+	t.Run("none mode accepts arbitrary credentials", func(t *testing.T) {
+		resetViper(t)
+		mqttTCP := localAddr(freeTCPPort(t))
+		_, cleanup := startBrokerForTest(t, mqttTCP, func() {
+			viper.Set("MQTT.auth.mode", "none")
+		})
+		defer cleanup()
+
+		c := pahoConnectExpectingSuccess(t, mqttTCP, "auth-none-junk", "anyone", "anything")
+		c.Disconnect(50)
+	})
+
+	t.Run("password mode accepts valid credentials", func(t *testing.T) {
+		resetViper(t)
+		mqttTCP := localAddr(freeTCPPort(t))
+		_, cleanup := startBrokerForTest(t, mqttTCP, func() {
+			viper.Set("MQTT.auth", map[string]interface{}{
+				"mode": "password",
+				"users": []map[string]string{
+					{"username": "alice", "password": "alice-pw"},
+					{"username": "bob", "password": "bob-pw"},
+				},
+			})
+		})
+		defer cleanup()
+
+		c := pahoConnectExpectingSuccess(t, mqttTCP, "auth-pw-valid", "alice", "alice-pw")
+		c.Disconnect(50)
+	})
+
+	t.Run("password mode rejects wrong password", func(t *testing.T) {
+		resetViper(t)
+		mqttTCP := localAddr(freeTCPPort(t))
+		_, cleanup := startBrokerForTest(t, mqttTCP, func() {
+			viper.Set("MQTT.auth", map[string]interface{}{
+				"mode": "password",
+				"users": []map[string]string{
+					{"username": "alice", "password": "alice-pw"},
+				},
+			})
+		})
+		defer cleanup()
+
+		pahoConnectExpectingRejection(t, mqttTCP, "auth-pw-wrong", "alice", "wrong-password")
+	})
+
+	t.Run("password mode rejects unknown user", func(t *testing.T) {
+		resetViper(t)
+		mqttTCP := localAddr(freeTCPPort(t))
+		_, cleanup := startBrokerForTest(t, mqttTCP, func() {
+			viper.Set("MQTT.auth", map[string]interface{}{
+				"mode": "password",
+				"users": []map[string]string{
+					{"username": "alice", "password": "alice-pw"},
+				},
+			})
+		})
+		defer cleanup()
+
+		pahoConnectExpectingRejection(t, mqttTCP, "auth-pw-unknown", "carol", "carol-pw")
+	})
+}
+
+// F: forwarding 無効化
+//
+// auth.mode=none かつ allow_unauthenticated_forwards=false の組み合わせでは、
+// MQTT publish が UDP 転送先に到達しないことを確認する。
+// （未認証クライアントの publish が UDP ストリームへ任意注入されることを防ぐ仕様）
+func TestIntegration_ForwardingDisabledWhenUnauthenticated(t *testing.T) {
+	resetViper(t)
+
+	mqttTCP := localAddr(freeTCPPort(t))
+	mqttWS := localAddr(freeTCPPort(t))
+	forwardPort := freeUDPPort(t)
+	forwardAddr := localAddr(forwardPort)
+
+	const topic = "test/integration/forwarding-disabled"
+
+	viper.Set("UDP.forwards", map[string][]string{forwardAddr: {topic}})
+	viper.Set("UDP.allow_unauthenticated_forwards", false)
+	viper.Set("MQTT.tcp", mqttTCP)
+	viper.Set("MQTT.websocket", mqttWS)
+	viper.Set("MQTT.auth.mode", "none")
+
+	udpRecv, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: forwardPort})
+	require.NoError(t, err)
+	defer udpRecv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	msgCh := make(chan UdpMessage, 1)
+
+	wg.Add(1)
+	go startMQTTBroker(ctx, &wg, errCh, msgCh)
+
+	waitForTCP(t, mqttTCP, 2*time.Second)
+
+	c := pahoConnectExpectingSuccess(t, mqttTCP, "fwd-disabled-pub", "", "")
+	defer c.Disconnect(250)
+
+	pubToken := c.Publish(topic, 1, false, "should-not-be-forwarded")
+	require.True(t, pubToken.WaitTimeout(2*time.Second))
+	require.NoError(t, pubToken.Error())
+
+	// 転送先 UDP ソケットでパケットが来ないことを assert (短時間タイムアウト)
+	require.NoError(t, udpRecv.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
+	buf := make([]byte, 1024)
+	n, _, readErr := udpRecv.ReadFromUDP(buf)
+
+	if readErr == nil {
+		t.Fatalf("forwarding should be disabled but received UDP packet: %q", buf[:n])
+	}
+	var ne net.Error
+	require.True(t, errors.As(readErr, &ne) && ne.Timeout(),
+		"expected timeout (no packet), got: %v", readErr)
+	assert.Equal(t, 0, n)
+
+	cancel()
+	waitWG(t, &wg, 3*time.Second)
+	drainErr(t, errCh)
+}

--- a/cmd/integration_payload_test.go
+++ b/cmd/integration_payload_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// G: 不正な UDP ペイロード
+//
+// 改行なし / 空トピックを含む不正パケットを送信しても UDP リスナーが
+// 落ちず、後続の正常パケットは引き続き msgCh に流れることを確認する。
+func TestIntegration_UDPInvalidPayloadDoesNotCrash(t *testing.T) {
+	resetViper(t)
+
+	udpListenAddr := localAddr(freeUDPPort(t))
+	viper.Set("UDP.listen", udpListenAddr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	msgCh := make(chan UdpMessage, 4)
+
+	wg.Add(1)
+	go startUDPListener(ctx, &wg, errCh, msgCh)
+
+	// リスナーが listen を開始するまで少し待つ。
+	// UDP は connectionless だが、ListenUDP の bind 完了を待たないと
+	// 送信パケットが破棄される可能性がある。
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("udp", udpListenAddr, 100*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 2*time.Second, 50*time.Millisecond)
+
+	udpAddr, err := net.ResolveUDPAddr("udp", udpListenAddr)
+	require.NoError(t, err)
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// 不正パケットを送る
+	invalidPayloads := [][]byte{
+		[]byte("no-newline-here"),     // 改行なし
+		[]byte("\nempty-topic"),       // 空トピック
+		[]byte(""),                    // 完全に空
+		[]byte("\n"),                  // 改行のみ
+	}
+	for _, p := range invalidPayloads {
+		_, err := conn.Write(p)
+		require.NoError(t, err)
+	}
+
+	// 不正パケット送信後に msgCh に何も流れていないこと
+	select {
+	case msg := <-msgCh:
+		t.Fatalf("invalid payload should not produce message, got: %#v", msg)
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing arrives
+	}
+
+	// 続けて正常パケットを送り、リスナーがまだ生きていることを確認
+	const validTopic = "test/integration/valid-after-invalid"
+	const validPayload = "still-alive"
+	_, err = conn.Write([]byte(validTopic + "\n" + validPayload))
+	require.NoError(t, err)
+
+	select {
+	case msg := <-msgCh:
+		assert.Equal(t, validTopic, msg.Topic)
+		assert.Equal(t, validPayload, msg.Payload)
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener appears to have died: valid packet not received after invalid ones")
+	}
+
+	// 念のためもう一度正常パケット (連続稼働の確認)
+	const validTopic2 = "test/integration/second-valid"
+	const validPayload2 = "second"
+	_, err = conn.Write([]byte(validTopic2 + "\n" + validPayload2))
+	require.NoError(t, err)
+
+	select {
+	case msg := <-msgCh:
+		assert.Equal(t, validTopic2, msg.Topic)
+		assert.Equal(t, validPayload2, msg.Payload)
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener died after second valid packet")
+	}
+
+	cancel()
+	waitWG(t, &wg, 3*time.Second)
+	drainErr(t, errCh)
+}

--- a/cmd/integration_tls_test.go
+++ b/cmd/integration_tls_test.go
@@ -1,0 +1,230 @@
+//go:build integration
+
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateSelfSignedCert は ECDSA P-256 鍵で自己署名 X.509 証明書を生成する。
+// hosts は SubjectAlternativeName として埋め込まれる
+// (IP リテラルなら IPAddresses、それ以外は DNSNames として登録)。
+func generateSelfSignedCert(t *testing.T, hosts []string) (certPEM, keyPEM []byte, parsed *x509.Certificate) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "driensten-integration-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	parsed, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return
+}
+
+// writeCertFiles は cert/key の PEM をテンポラリディレクトリに書き出してパスを返す。
+func writeCertFiles(t *testing.T, certPEM, keyPEM []byte) (certPath, keyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+	return
+}
+
+// H: HTTP TLS 配信
+//
+// 自己署名 cert で startWebServer を TLS 起動し、
+// その cert を root CA として信頼するクライアントから https GET できることを確認する。
+func TestIntegration_HTTPTLSStaticServing(t *testing.T) {
+	resetViper(t)
+
+	distDir := t.TempDir()
+	contents := []byte("tls hello")
+	require.NoError(t, os.WriteFile(filepath.Join(distDir, "tls.txt"), contents, 0o644))
+
+	certPEM, keyPEM, parsedCert := generateSelfSignedCert(t, []string{"127.0.0.1"})
+	certPath, keyPath := writeCertFiles(t, certPEM, keyPEM)
+
+	addr := localAddr(freeTCPPort(t))
+	viper.Set("HTTP.listen", addr)
+	viper.Set("HTTP.root", distDir)
+	viper.Set("HTTP.tls.enable", true)
+	viper.Set("HTTP.tls.cert", certPath)
+	viper.Set("HTTP.tls.key", keyPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	wg.Add(1)
+	go startWebServer(ctx, &wg, errCh)
+
+	waitForTCP(t, addr, 2*time.Second)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(parsedCert)
+	httpClient := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+
+	resp, err := httpClient.Get("https://" + addr + "/tls.txt")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, contents, body)
+
+	cancel()
+	waitWG(t, &wg, 3*time.Second)
+	drainErr(t, errCh)
+}
+
+// I-a: MQTT TLS トランスポート
+//
+// 自己署名 cert で MQTT broker を TLS 起動し、paho クライアントが
+// tls:// で接続して publish/subscribe の往復ができることを確認する。
+//
+// 注: 本テストは TLS による通信路の暗号化のみを検証する。
+// auth.mode="cert" のクライアント証明書認証は現状の startMQTTBroker が
+// tls.Config に ClientAuth/ClientCAs を設定しないため動作しない。
+// 当該検証は本 PR の対象外とし、別 PR でコード修正と合わせて対応する。
+func TestIntegration_MQTTTLSTransport(t *testing.T) {
+	resetViper(t)
+
+	certPEM, keyPEM, parsedCert := generateSelfSignedCert(t, []string{"127.0.0.1"})
+	certPath, keyPath := writeCertFiles(t, certPEM, keyPEM)
+
+	mqttTCP := localAddr(freeTCPPort(t))
+	mqttWS := localAddr(freeTCPPort(t))
+	forwardAddr := localAddr(freeUDPPort(t))
+
+	const topic = "test/integration/mqtt-tls"
+	const payload = "tls-payload"
+
+	viper.Set("UDP.forwards", map[string][]string{forwardAddr: {topic}})
+	viper.Set("UDP.allow_unauthenticated_forwards", true)
+	viper.Set("MQTT.tcp", mqttTCP)
+	viper.Set("MQTT.websocket", mqttWS)
+	viper.Set("MQTT.tls.enable", true)
+	viper.Set("MQTT.tls.cert", certPath)
+	viper.Set("MQTT.tls.key", keyPath)
+	viper.Set("MQTT.auth.mode", "none")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	msgCh := make(chan UdpMessage, 1)
+
+	wg.Add(1)
+	go startMQTTBroker(ctx, &wg, errCh, msgCh)
+
+	waitForTCP(t, mqttTCP, 2*time.Second)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(parsedCert)
+
+	opts := paho.NewClientOptions().
+		AddBroker("tls://" + mqttTCP).
+		SetClientID("test-mqtt-tls").
+		SetTLSConfig(&tls.Config{RootCAs: pool, ServerName: "127.0.0.1"}).
+		SetConnectTimeout(3 * time.Second).
+		SetAutoReconnect(false)
+
+	client := paho.NewClient(opts)
+	connectToken := client.Connect()
+	require.True(t, connectToken.WaitTimeout(3*time.Second), "MQTT TLS connect timeout")
+	require.NoError(t, connectToken.Error())
+	defer client.Disconnect(250)
+
+	received := make(chan paho.Message, 1)
+	subToken := client.Subscribe(topic, 1, func(_ paho.Client, m paho.Message) {
+		received <- m
+	})
+	require.True(t, subToken.WaitTimeout(2*time.Second), "MQTT TLS subscribe timeout")
+	require.NoError(t, subToken.Error())
+
+	pubToken := client.Publish(topic, 1, false, payload)
+	require.True(t, pubToken.WaitTimeout(2*time.Second), "MQTT TLS publish timeout")
+	require.NoError(t, pubToken.Error())
+
+	select {
+	case m := <-received:
+		assert.Equal(t, topic, m.Topic())
+		assert.Equal(t, payload, string(m.Payload()))
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive message over TLS")
+	}
+
+	cancel()
+	waitWG(t, &wg, 3*time.Second)
+	drainErr(t, errCh)
+}


### PR DESCRIPTION
## Summary

Phase 1 の統合テスト基盤の上に、業務ロジック (Phase 2) と TLS (Phase 3) のテストを追加。
全テスト `//go:build integration` で分離。

## 追加テスト

### Phase 2: 業務ロジック
| テスト | 検証内容 | サブケース数 |
|---|---|---|
| `TestIntegration_MQTTAuth` | none/password モードでの認証可否を paho で実接続検証 | 5 |
| `TestIntegration_ForwardingDisabledWhenUnauthenticated` | `auth.mode=none` × `allow_unauthenticated_forwards=false` で MQTT→UDP 転送がスキップされる | 1 |
| `TestIntegration_UDPInvalidPayloadDoesNotCrash` | 改行なし / 空トピック / 空 / 改行のみ の不正パケット 4 種を送信後、UDP リスナーが継続稼働して正常パケットを処理できる | 1 |

E のサブケース内訳:
- `none` モードでクレデンシャルなし接続が許可される
- `none` モードで任意のクレデンシャル接続が許可される
- `password` モードで正規ユーザが許可される
- `password` モードで誤パスワードが拒否される
- `password` モードで未登録ユーザが拒否される

### Phase 3: TLS
| テスト | 検証内容 |
|---|---|
| `TestIntegration_HTTPTLSStaticServing` | 自己署名 cert で `startWebServer` を TLS 起動し、cert を信頼する HTTP クライアントで GET → 200 + 内容一致 |
| `TestIntegration_MQTTTLSTransport` | 自己署名 cert で MQTT broker を TLS 起動し、paho が `tls://` で接続して publish/subscribe 往復 |

## 共通基盤の追加

- `cmd/integration_auth_test.go` 内の `startBrokerForTest` / `pahoConnectExpectingSuccess` / `pahoConnectExpectingRejection` で、認証系テストの繰り返し記述を圧縮
- `cmd/integration_tls_test.go` 内の `generateSelfSignedCert` (ECDSA P-256) / `writeCertFiles` で TLS テストの cert を即席生成 (CA 構造なし、サーバ cert のみのシンプル構成)

## 対象外: cert 認証 (`auth.mode=\"cert\"`)

cert 認証モードを paho で動作確認しようとしたところ、現コードに以下の問題があることが判明:

- [cmd/mqtt.go](https://github.com/ramsesyok/driensten/blob/main/cmd/mqtt.go) の `startMQTTBroker` で TLS 設定時に `tls.Config{Certificates: ...}` のみを設定しており、`ClientAuth` / `ClientCAs` を指定していない
- 結果として、サーバはクライアント証明書を要求しないため、`OnConnectAuthenticate` で参照する `tlsConn.ConnectionState().PeerCertificates` は常に空となり、cert モードは常に拒否される

修正にはサーバ側 `tls.Config` への `ClientAuth: tls.RequireAndVerifyClientCert` 追加と、CA 証明書を読み込む新規設定キー (`MQTT.tls.client_ca` 等) の導入が必要なため、本 PR の \"テスト追加\" スコープを超えます。
**コード修正 + テスト追加を含む別 PR で対応する想定**です。

## 実行方法

\`\`\`
go test -tags=integration -race ./...
\`\`\`

既定の \`go test ./...\` には影響しません。

## 安定性

- 全 9 テスト (Phase 1+2+3 合計、サブケース込み 13 ケース) を `-count=2 -race` で 2 周連続 PASS 確認
- 各テストはエフェメラルポート (`:0` で OS 割当) を使用するため並行 CI でも衝突しにくい
- 認証系の各サブテストは独立した broker 起動 (各回ポート異なる) で副作用なし

## Test plan

- [x] \`go vet ./...\`
- [x] \`go vet -tags=integration ./...\`
- [x] \`go test -race ./...\` (既定実行への影響なし)
- [x] \`go test -tags=integration -race -count=2 ./...\` (全テスト x2 周 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)