### PR TITLE
mqtt: cert 認証モードを正しく機能させる修正と検証テストを追加

### DIFF
--- a/cmd/integration_cert_auth_test.go
+++ b/cmd/integration_cert_auth_test.go
@@ -1,0 +1,259 @@
+//go:build integration
+
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pahoTLSConnect は paho クライアントを TLS で接続する。
+// expectError=true の場合、token に Error が乗ることを assert する。
+func pahoTLSConnect(t *testing.T, brokerAddr, clientID string, tlsConf *tls.Config, expectError bool) paho.Client {
+	t.Helper()
+	opts := paho.NewClientOptions().
+		AddBroker("tls://" + brokerAddr).
+		SetClientID(clientID).
+		SetTLSConfig(tlsConf).
+		SetConnectTimeout(3 * time.Second).
+		SetAutoReconnect(false)
+
+	c := paho.NewClient(opts)
+	tok := c.Connect()
+	require.True(t, tok.WaitTimeout(3*time.Second), "connect token did not complete")
+	if expectError {
+		require.Error(t, tok.Error(), "connect should have failed")
+	} else {
+		require.NoError(t, tok.Error(), "connect should have succeeded")
+	}
+	return c
+}
+
+// buildClientTLSConfig は CA を信頼し、必要なら client cert を提示する設定を組み立てる。
+// clientCert が nil の場合はクライアント証明書を提示しない。
+func buildClientTLSConfig(rootPool *x509.CertPool, clientCert *x509.Certificate, clientKey *ecdsa.PrivateKey, serverName string) *tls.Config {
+	conf := &tls.Config{
+		RootCAs:    rootPool,
+		ServerName: serverName,
+	}
+	if clientCert != nil {
+		conf.Certificates = []tls.Certificate{
+			{
+				Certificate: [][]byte{clientCert.Raw},
+				PrivateKey:  clientKey,
+				Leaf:        clientCert,
+			},
+		}
+	}
+	return conf
+}
+
+// I-b: MQTT cert 認証
+//
+// CA → server cert + 正規 client cert + 別 CA 由来の不正 client cert を生成し、
+// auth.mode=cert で起動した broker への paho 接続が以下のように振る舞うことを確認する:
+//   - 正規クライアント証明書: 接続成功 + publish/subscribe 往復
+//   - クライアント証明書なし: TLS ハンドシェイク失敗
+//   - 別 CA で署名された証明書: TLS ハンドシェイク失敗
+func TestIntegration_MQTTCertAuth(t *testing.T) {
+	resetViper(t)
+
+	// 信頼する CA とそれに紐づく server / client cert
+	ca, caKey := generateTestCA(t)
+	serverCert, serverKey := signLeafCert(t, ca, caKey, []string{"127.0.0.1"}, false)
+	validClientCert, validClientKey := signLeafCert(t, ca, caKey, nil, true)
+
+	// 信頼しない別 CA とその配下の client cert (拒否されるべき)
+	rogueCA, rogueCAKey := generateTestCA(t)
+	rogueClientCert, rogueClientKey := signLeafCert(t, rogueCA, rogueCAKey, nil, true)
+
+	// ファイル配置
+	dir := t.TempDir()
+	serverCertPath := filepath.Join(dir, "server.crt")
+	serverKeyPath := filepath.Join(dir, "server.key")
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(serverCertPath, certPEM(serverCert), 0o600))
+	require.NoError(t, os.WriteFile(serverKeyPath, keyPEM(t, serverKey), 0o600))
+	require.NoError(t, os.WriteFile(caPath, certPEM(ca), 0o600))
+
+	mqttTCP := localAddr(freeTCPPort(t))
+	mqttWS := localAddr(freeTCPPort(t))
+	forwardAddr := localAddr(freeUDPPort(t))
+
+	const topic = "test/integration/cert-auth"
+
+	viper.Set("UDP.forwards", map[string][]string{forwardAddr: {topic}})
+	viper.Set("UDP.allow_unauthenticated_forwards", false)
+	viper.Set("MQTT.tcp", mqttTCP)
+	viper.Set("MQTT.websocket", mqttWS)
+	viper.Set("MQTT.tls.enable", true)
+	viper.Set("MQTT.tls.cert", serverCertPath)
+	viper.Set("MQTT.tls.key", serverKeyPath)
+	viper.Set("MQTT.tls.client_ca", caPath)
+	viper.Set("MQTT.auth.mode", "cert")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	msgCh := make(chan UdpMessage, 1)
+
+	wg.Add(1)
+	go startMQTTBroker(ctx, &wg, errCh, msgCh)
+	waitForTCP(t, mqttTCP, 2*time.Second)
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(ca)
+
+	t.Run("valid client cert is accepted with publish round-trip", func(t *testing.T) {
+		conf := buildClientTLSConfig(rootPool, validClientCert, validClientKey, "127.0.0.1")
+		c := pahoTLSConnect(t, mqttTCP, "cert-valid", conf, false)
+		defer c.Disconnect(50)
+
+		received := make(chan paho.Message, 1)
+		subTok := c.Subscribe(topic, 1, func(_ paho.Client, m paho.Message) {
+			received <- m
+		})
+		require.True(t, subTok.WaitTimeout(2*time.Second))
+		require.NoError(t, subTok.Error())
+
+		const payload = "cert-payload"
+		pubTok := c.Publish(topic, 1, false, payload)
+		require.True(t, pubTok.WaitTimeout(2*time.Second))
+		require.NoError(t, pubTok.Error())
+
+		select {
+		case m := <-received:
+			assert.Equal(t, topic, m.Topic())
+			assert.Equal(t, payload, string(m.Payload()))
+		case <-time.After(3 * time.Second):
+			t.Fatal("did not receive published message over cert-authenticated TLS")
+		}
+	})
+
+	t.Run("client without cert is rejected", func(t *testing.T) {
+		conf := buildClientTLSConfig(rootPool, nil, nil, "127.0.0.1")
+		_ = pahoTLSConnect(t, mqttTCP, "cert-none", conf, true)
+	})
+
+	t.Run("client cert from different CA is rejected", func(t *testing.T) {
+		conf := buildClientTLSConfig(rootPool, rogueClientCert, rogueClientKey, "127.0.0.1")
+		_ = pahoTLSConnect(t, mqttTCP, "cert-rogue", conf, true)
+	})
+
+	cancel()
+	waitWG(t, &wg, 3*time.Second)
+	drainErr(t, errCh)
+}
+
+// I-b 補完: cert 認証の設定不備で startMQTTBroker が起動時にエラーで終了する。
+func TestIntegration_MQTTCertAuthMisconfigured(t *testing.T) {
+	type runResult struct {
+		err error
+	}
+
+	startAndCollectErr := func(t *testing.T, configure func()) runResult {
+		t.Helper()
+		resetViper(t)
+		configure()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var wg sync.WaitGroup
+		errCh := make(chan error, 1)
+		msgCh := make(chan UdpMessage, 1)
+
+		wg.Add(1)
+		go startMQTTBroker(ctx, &wg, errCh, msgCh)
+
+		// broker は起動失敗で wg.Done() するはず
+		waitWG(t, &wg, 2*time.Second)
+
+		select {
+		case err := <-errCh:
+			return runResult{err: err}
+		default:
+			return runResult{err: nil}
+		}
+	}
+
+	t.Run("cert mode without TLS errors at startup", func(t *testing.T) {
+		mqttTCP := localAddr(freeTCPPort(t))
+		mqttWS := localAddr(freeTCPPort(t))
+		res := startAndCollectErr(t, func() {
+			viper.Set("MQTT.tcp", mqttTCP)
+			viper.Set("MQTT.websocket", mqttWS)
+			viper.Set("MQTT.tls.enable", false)
+			viper.Set("MQTT.auth.mode", "cert")
+		})
+		require.Error(t, res.err)
+		assert.Contains(t, res.err.Error(), "MQTT.tls.enable")
+	})
+
+	t.Run("cert mode without client_ca errors at startup", func(t *testing.T) {
+		ca, caKey := generateTestCA(t)
+		serverCert, serverKey := signLeafCert(t, ca, caKey, []string{"127.0.0.1"}, false)
+		certPath, keyPath := writeCertFiles(t, certPEM(serverCert), keyPEM(t, serverKey))
+
+		mqttTCP := localAddr(freeTCPPort(t))
+		mqttWS := localAddr(freeTCPPort(t))
+		res := startAndCollectErr(t, func() {
+			viper.Set("MQTT.tcp", mqttTCP)
+			viper.Set("MQTT.websocket", mqttWS)
+			viper.Set("MQTT.tls.enable", true)
+			viper.Set("MQTT.tls.cert", certPath)
+			viper.Set("MQTT.tls.key", keyPath)
+			viper.Set("MQTT.auth.mode", "cert")
+			// client_ca 未設定
+		})
+		require.Error(t, res.err)
+		assert.Contains(t, res.err.Error(), "MQTT.tls.client_ca")
+	})
+
+	t.Run("cert mode with nonexistent client_ca errors at startup", func(t *testing.T) {
+		ca, caKey := generateTestCA(t)
+		serverCert, serverKey := signLeafCert(t, ca, caKey, []string{"127.0.0.1"}, false)
+		certPath, keyPath := writeCertFiles(t, certPEM(serverCert), keyPEM(t, serverKey))
+
+		mqttTCP := localAddr(freeTCPPort(t))
+		mqttWS := localAddr(freeTCPPort(t))
+		res := startAndCollectErr(t, func() {
+			viper.Set("MQTT.tcp", mqttTCP)
+			viper.Set("MQTT.websocket", mqttWS)
+			viper.Set("MQTT.tls.enable", true)
+			viper.Set("MQTT.tls.cert", certPath)
+			viper.Set("MQTT.tls.key", keyPath)
+			viper.Set("MQTT.tls.client_ca", filepath.Join(t.TempDir(), "nonexistent-ca.pem"))
+			viper.Set("MQTT.auth.mode", "cert")
+		})
+		require.Error(t, res.err)
+		assert.Contains(t, res.err.Error(), "client CA")
+	})
+}

--- a/cmd/integration_tls_test.go
+++ b/cmd/integration_tls_test.go
@@ -82,6 +82,82 @@ func generateSelfSignedCert(t *testing.T, hosts []string) (certPEM, keyPEM []byt
 	return
 }
 
+// generateTestCA は自己署名のテスト用 root CA を生成する。
+// 戻り値の証明書 + 秘密鍵で leaf 証明書に署名する。
+func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "driensten-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return parsed, priv
+}
+
+// signLeafCert は ca + caKey で leaf 証明書に署名する。
+// hosts が指定されていれば SAN として登録 (server cert 用)。
+// isClient=true なら ExtKeyUsage を ClientAuth、false なら ServerAuth とする。
+func signLeafCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, hosts []string, isClient bool) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	eku := x509.ExtKeyUsageServerAuth
+	cn := "driensten-test-server"
+	if isClient {
+		eku = x509.ExtKeyUsageClientAuth
+		cn = "driensten-test-client"
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &priv.PublicKey, caKey)
+	require.NoError(t, err)
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return parsed, priv
+}
+
+// certPEM は X.509 証明書を PEM エンコードする。
+func certPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// keyPEM は ECDSA 秘密鍵を PEM エンコードする。
+func keyPEM(t *testing.T, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
 // writeCertFiles は cert/key の PEM をテンポラリディレクトリに書き出してパスを返す。
 func writeCertFiles(t *testing.T, certPEM, keyPEM []byte) (certPath, keyPath string) {
 	t.Helper()

--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -19,8 +19,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"strings"
 	"sync"
 
@@ -93,6 +97,35 @@ func buildTopicToAddressMap(forwards map[string][]string) map[string]string {
 	return topics
 }
 
+// validateMQTTAuthConfig は MQTT 認証設定の整合性を確認する。
+// cert モードは TLS 有効化と client_ca 指定が必須。それ以外のモードは無条件で OK。
+func validateMQTTAuthConfig(mode string, tlsEnable bool, clientCAPath string) error {
+	if mode != "cert" {
+		return nil
+	}
+	if !tlsEnable {
+		return errors.New("MQTT.auth.mode=cert requires MQTT.tls.enable=true")
+	}
+	if clientCAPath == "" {
+		return errors.New("MQTT.auth.mode=cert requires MQTT.tls.client_ca to be set")
+	}
+	return nil
+}
+
+// loadClientCAPool は指定された PEM ファイルを読み込み、x509.CertPool を返す。
+// ファイルに有効な証明書が 1 つも含まれない場合はエラー。
+func loadClientCAPool(path string) (*x509.CertPool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read client CA file: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("no valid certificates found in %s", path)
+	}
+	return pool, nil
+}
+
 type mqttAuthHook struct {
 	mqtt.HookBase
 	cfg mqttAuthConfig
@@ -156,6 +189,14 @@ func startMQTTBroker(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error
 		authCfg.Mode = "none"
 	}
 	slog.Info("load configuration", slog.String("MQTT.auth.mode", authCfg.Mode))
+
+	clientCAPath := viper.GetString("MQTT.tls.client_ca")
+	if err := validateMQTTAuthConfig(authCfg.Mode, tlsEnable, clientCAPath); err != nil {
+		slog.Error("mqtt auth misconfigured", slog.String("error", err.Error()))
+		errCh <- err
+		return
+	}
+
 	if authCfg.Mode == "none" {
 		slog.Warn("MQTT authentication is DISABLED (MQTT.auth.mode=none) - do not use in production")
 	}
@@ -171,6 +212,20 @@ func startMQTTBroker(ctx context.Context, wg *sync.WaitGroup, errCh chan<- error
 			return
 		}
 		tlsConfig = &tls.Config{Certificates: []tls.Certificate{cert}}
+
+		// cert 認証モードでは TLS 層でクライアント証明書を要求・検証する。
+		// 検証に通った接続のみ OnConnectAuthenticate (PeerCertificates チェック) に到達する。
+		if authCfg.Mode == "cert" {
+			pool, err := loadClientCAPool(clientCAPath)
+			if err != nil {
+				slog.Error("mqtt failed to load client CA", slog.String("error", err.Error()))
+				errCh <- err
+				return
+			}
+			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			tlsConfig.ClientCAs = pool
+			slog.Info("load configuration", slog.String("MQTT.tls.client_ca", clientCAPath))
+		}
 	}
 
 	// TCP待ち受け

--- a/cmd/mqtt_test.go
+++ b/cmd/mqtt_test.go
@@ -16,7 +16,17 @@ limitations under the License.
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,5 +229,110 @@ func TestBuildTopicToAddressMap(t *testing.T) {
 			"127.0.0.1:6000": {},
 		})
 		assert.Empty(t, got)
+	})
+}
+
+func TestValidateMQTTAuthConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		tlsEnable bool
+		caPath    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "none mode passes regardless", mode: "none", wantErr: false},
+		{name: "password mode passes regardless", mode: "password", wantErr: false},
+		{name: "empty mode passes (treated as none upstream)", mode: "", wantErr: false},
+		{name: "unknown mode passes (only cert is validated)", mode: "future", wantErr: false},
+
+		{name: "cert mode without TLS errors", mode: "cert", tlsEnable: false, caPath: "/some/ca.pem", wantErr: true, errSubstr: "MQTT.tls.enable"},
+		{name: "cert mode without client_ca errors", mode: "cert", tlsEnable: true, caPath: "", wantErr: true, errSubstr: "MQTT.tls.client_ca"},
+		{name: "cert mode without TLS or CA errors on TLS first", mode: "cert", tlsEnable: false, caPath: "", wantErr: true, errSubstr: "MQTT.tls.enable"},
+		{name: "cert mode with TLS and CA passes", mode: "cert", tlsEnable: true, caPath: "/some/ca.pem", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMQTTAuthConfig(tt.mode, tt.tlsEnable, tt.caPath)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// generateCertPEMForTest は単一の自己署名 X.509 証明書 PEM を返す。
+// loadClientCAPool テスト用。integration ビルドタグで使う TLS ヘルパに頼らないため
+// ここで直接生成する。
+func generateCertPEMForTest(t *testing.T) []byte {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "unit-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestLoadClientCAPool(t *testing.T) {
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		_, err := loadClientCAPool(filepath.Join(t.TempDir(), "does-not-exist.pem"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read client CA file")
+	})
+
+	t.Run("empty file returns error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "empty.pem")
+		require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+		_, err := loadClientCAPool(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid certificates")
+	})
+
+	t.Run("garbage content returns error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "garbage.pem")
+		require.NoError(t, os.WriteFile(path, []byte("this is not a PEM"), 0o600))
+		_, err := loadClientCAPool(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid certificates")
+	})
+
+	t.Run("valid CA PEM returns non-empty pool", func(t *testing.T) {
+		pemBytes := generateCertPEMForTest(t)
+		path := filepath.Join(t.TempDir(), "ca.pem")
+		require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
+
+		pool, err := loadClientCAPool(path)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
+		// CertPool に内容が入っているか確認 (Equal で空 pool との非一致を見る)
+		assert.False(t, pool.Equal(x509.NewCertPool()), "pool should not be empty")
+	})
+
+	t.Run("multiple CAs concatenated PEM are all loaded", func(t *testing.T) {
+		pem1 := generateCertPEMForTest(t)
+		pem2 := generateCertPEMForTest(t)
+		combined := append(append([]byte{}, pem1...), pem2...)
+		path := filepath.Join(t.TempDir(), "multi-ca.pem")
+		require.NoError(t, os.WriteFile(path, combined, 0o600))
+
+		pool, err := loadClientCAPool(path)
+		require.NoError(t, err)
+		require.NotNil(t, pool)
 	})
 }

--- a/driensten.yaml
+++ b/driensten.yaml
@@ -16,11 +16,14 @@ MQTT:
     #     password: secret
     #   - username: bob
     #     password: pass123
-    # cert モードは MQTT.tls.enable: true が必要
+    # cert モードは MQTT.tls.enable: true と MQTT.tls.client_ca の指定が必要
   tls:
     enable: false
     cert: server.crt
     key: server.key
+    # cert 認証モード時に信頼するクライアント証明書 CA (PEM)。
+    # 1 ファイルに複数 CA を連結指定可。cert モード以外では無視される。
+    # client_ca: client-ca.pem
 UDP:
   listen: 127.0.0.1:6565
   # MQTT.auth.mode が none のとき、MQTT→UDP 転送を有効にするには true を指定する。


### PR DESCRIPTION
これまで auth.mode=cert は startMQTTBroker 側で tls.Config に ClientAuth/ClientCAs を設定していなかったため、TLS 層がクライアント
証明書を要求せず、OnConnectAuthenticate の PeerCertificates チェックは 常に空となり、cert モード接続は常に拒否されていた。

修正内容:
- 新規 viper キー MQTT.tls.client_ca を追加 (信頼する CA の PEM パス、 複数 CA の連結指定可)
- auth.mode=cert のときに TLS 層で ClientAuth = RequireAndVerifyClientCert + ClientCAs = pool を設定し、 サーバが client cert を要求 + チェーン検証するように
- 起動時に validateMQTTAuthConfig で設定不備 (TLS 無効 / client_ca 未指定) を検出し、broker 起動前に errCh で失敗させる
- driensten.yaml サンプルに client_ca のコメント例を追記

抽出した純粋関数:
- validateMQTTAuthConfig(mode, tlsEnable, clientCAPath) error
- loadClientCAPool(path) (*x509.CertPool, error)

追加テスト:
- 単体: TestValidateMQTTAuthConfig (8 ケース) / TestLoadClientCAPool (5 ケース、自己生成 CA を含む)
- 統合 (//go:build integration):
  - TestIntegration_MQTTCertAuth: 正規 cert で publish/subscribe 往復、 cert 未提示・別 CA 由来 cert は TLS ハンドシェイクで拒否
  - TestIntegration_MQTTCertAuthMisconfigured: 設定不備時に startup error

cert/key/CA 証明書生成ヘルパ (generateTestCA, signLeafCert, certPEM, keyPEM) を integration_tls_test.go に追加。