### PR TITLE
ci: GitHub Actions で単体・統合テストを自動化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test (unit)
+        run: go test -race -timeout=180s ./...
+
+  integration:
+    name: Integration Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go vet (integration)
+        run: go vet -tags=integration ./...
+
+      - name: go test (integration)
+        run: go test -tags=integration -race -timeout=600s ./...


### PR DESCRIPTION
## Summary

push (main) と pull_request トリガーで、Linux/Windows 上で単体テストと統合テストを並列実行する CI を追加。

## ジョブ構成

| ジョブ | OS | 内容 |
|---|---|---|
| Unit Test | ubuntu-latest | \`go vet ./...\` → \`go build ./...\` → \`go test -race -timeout=180s ./...\` |
| Unit Test | windows-latest | 同上 |
| Integration Test | ubuntu-latest | \`go vet -tags=integration ./...\` → \`go test -tags=integration -race -timeout=600s ./...\` |
| Integration Test | windows-latest | 同上 |

\`fail-fast: false\` で 1 OS での失敗が他 OS のテスト実行を停止しないように設定。

## 設計上の判断

| 判断 | 理由 |
|---|---|
| Go バージョンを \`go-version-file: go.mod\` から解決 | \`go.mod\` を単一のソースに。バージョン更新時の手当てが 1 箇所で済む |
| 単体と統合を別ジョブ | 単体が失敗しても統合の状況が分かる。並列で実行時間も短縮 |
| Linux + Windows のマトリクス | プロジェクトは Windows でも実行される (作者環境) ため OS 依存の検出を確保 |
| \`actions/setup-go@v5\` の \`cache: true\` | \`go.sum\` ベースでモジュールキャッシュ。CI 時間を短縮 |
| \`permissions: contents: read\` | 最小権限 (テスト実行のみで書き込み不要) |
| 統合テストのタイムアウト 600s | race detector 有効時に余裕を持たせる (ローカルでは 4 秒で完走) |

## ローカル検証

CI で実行されるコマンドと同一を Windows ローカルで PASS 確認:

\`\`\`
go vet ./...                                  # ✓
go build ./...                                # ✓
go test -race -timeout=180s ./...             # ✓
go vet -tags=integration ./...                # ✓
go test -tags=integration -race -timeout=600s ./...  # ✓
\`\`\`

## 採用見送り

| 項目 | 理由 |
|---|---|
| \`golangci-lint\` ジョブ | \`.golangci.yml\` 整備が前提。既存コードへの lint 適用方針を別途決めてから追加するのが無難 |
| カバレッジレポート (Codecov 等) | サードパーティ連携の権限/秘匿情報設定が必要。一段落してから別 PR で |
| ビルド成果物のリリース | リリースワークフローは別途検討 |
| \`gosec\` などのセキュリティスキャン | 個別判断が必要なため別 PR で |

## レビューポイント

- 既存 PR (#9, #10 等が未マージで残っていれば) は本 PR マージ後にリベースすると CI が走るようになります
- ブランチ保護で「Required status checks」を有効にする場合は、本 PR がマージされて main で 1 度走ったあと、ジョブ名が候補に出てから設定可能になります

🤖 Generated with [Claude Code](https://claude.com/claude-code)