### PR TITLE
feat: gencert サブコマンドによる自己署名証明書生成機能を追加

### DIFF
--- a/cmd/gencert.go
+++ b/cmd/gencert.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var gencertCmd = &cobra.Command{
+	Use:   "gencert",
+	Short: "TLS動作確認用の自己署名証明書を生成します",
+	Long: `CA証明書、サーバ証明書、クライアント証明書を生成します。
+生成した証明書は driensten.yaml の TLS 設定に利用できます。
+
+使用例:
+  driensten gencert ca
+  driensten gencert server --ca-cert ca.crt --ca-key ca.key
+  driensten gencert client --ca-cert ca.crt --ca-key ca.key`,
+}
+
+func init() {
+	rootCmd.AddCommand(gencertCmd)
+}
+
+func generateECKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+func marshalKeyPEM(key *ecdsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
+}
+
+func marshalCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+func writePEMFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}
+
+func loadCACert(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEMData, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CA証明書の読み込みに失敗: %w", err)
+	}
+	keyPEMData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CA秘密鍵の読み込みに失敗: %w", err)
+	}
+
+	block, _ := pem.Decode(certPEMData)
+	if block == nil {
+		return nil, nil, fmt.Errorf("CA証明書のPEMデコードに失敗")
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CA証明書のパースに失敗: %w", err)
+	}
+
+	block, _ = pem.Decode(keyPEMData)
+	if block == nil {
+		return nil, nil, fmt.Errorf("CA秘密鍵のPEMデコードに失敗")
+	}
+	caKey, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CA秘密鍵のパースに失敗: %w", err)
+	}
+
+	return caCert, caKey, nil
+}

--- a/cmd/gencert_ca.go
+++ b/cmd/gencert_ca.go
@@ -1,0 +1,93 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	caOutCert string
+	caOutKey  string
+	caDays    int
+	caCN      string
+)
+
+var gencertCACmd = &cobra.Command{
+	Use:   "ca",
+	Short: "自己署名のCA証明書と秘密鍵を生成します",
+	Long: `自己署名のルートCA証明書と秘密鍵を生成します。
+生成したCA証明書はサーバ証明書・クライアント証明書の署名に使用します。
+
+使用例:
+  driensten gencert ca
+  driensten gencert ca --out-cert my-ca.crt --out-key my-ca.key --days 730`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key, err := generateECKey()
+		if err != nil {
+			return fmt.Errorf("鍵の生成に失敗: %w", err)
+		}
+
+		template := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: caCN},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().AddDate(0, 0, caDays),
+			IsCA:                  true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+			BasicConstraintsValid: true,
+		}
+
+		der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		if err != nil {
+			return fmt.Errorf("証明書の生成に失敗: %w", err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return fmt.Errorf("証明書のパースに失敗: %w", err)
+		}
+
+		keyPEM, err := marshalKeyPEM(key)
+		if err != nil {
+			return fmt.Errorf("秘密鍵のエンコードに失敗: %w", err)
+		}
+		if err := writePEMFile(caOutCert, marshalCertPEM(cert)); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", caOutCert, err)
+		}
+		if err := writePEMFile(caOutKey, keyPEM); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", caOutKey, err)
+		}
+
+		fmt.Printf("CA証明書: %s\n", caOutCert)
+		fmt.Printf("CA秘密鍵: %s\n", caOutKey)
+		return nil
+	},
+}
+
+func init() {
+	gencertCmd.AddCommand(gencertCACmd)
+	gencertCACmd.Flags().StringVar(&caOutCert, "out-cert", "ca.crt", "CA証明書の出力パス")
+	gencertCACmd.Flags().StringVar(&caOutKey, "out-key", "ca.key", "CA秘密鍵の出力パス")
+	gencertCACmd.Flags().IntVar(&caDays, "days", 365, "有効期間（日数）")
+	gencertCACmd.Flags().StringVar(&caCN, "cn", "driensten-ca", "Common Name")
+}

--- a/cmd/gencert_client.go
+++ b/cmd/gencert_client.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	clientCACert  string
+	clientCAKey   string
+	clientOutCert string
+	clientOutKey  string
+	clientDays    int
+	clientCN      string
+)
+
+var gencertClientCmd = &cobra.Command{
+	Use:   "client",
+	Short: "CAで署名したクライアント証明書と秘密鍵を生成します",
+	Long: `指定したCAで署名したクライアント証明書と秘密鍵を生成します。
+MQTT のクライアント証明書認証（auth.mode=cert）で使用します。
+
+driensten.yaml の MQTT.tls.client_ca に CA 証明書のパスを設定し、
+生成したクライアント証明書を MQTT クライアント（例: mosquitto_pub）に渡してください。
+
+使用例:
+  driensten gencert client
+  driensten gencert client --cn my-device --out-cert device.crt --out-key device.key`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		caCert, caKey, err := loadCACert(clientCACert, clientCAKey)
+		if err != nil {
+			return err
+		}
+
+		key, err := generateECKey()
+		if err != nil {
+			return fmt.Errorf("鍵の生成に失敗: %w", err)
+		}
+
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: clientCN},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().AddDate(0, 0, clientDays),
+			KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			return fmt.Errorf("証明書の生成に失敗: %w", err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return fmt.Errorf("証明書のパースに失敗: %w", err)
+		}
+
+		keyPEM, err := marshalKeyPEM(key)
+		if err != nil {
+			return fmt.Errorf("秘密鍵のエンコードに失敗: %w", err)
+		}
+		if err := writePEMFile(clientOutCert, marshalCertPEM(cert)); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", clientOutCert, err)
+		}
+		if err := writePEMFile(clientOutKey, keyPEM); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", clientOutKey, err)
+		}
+
+		fmt.Printf("クライアント証明書: %s\n", clientOutCert)
+		fmt.Printf("クライアント秘密鍵: %s\n", clientOutKey)
+		return nil
+	},
+}
+
+func init() {
+	gencertCmd.AddCommand(gencertClientCmd)
+	gencertClientCmd.Flags().StringVar(&clientCACert, "ca-cert", "ca.crt", "CA証明書のパス")
+	gencertClientCmd.Flags().StringVar(&clientCAKey, "ca-key", "ca.key", "CA秘密鍵のパス")
+	gencertClientCmd.Flags().StringVar(&clientOutCert, "out-cert", "client.crt", "クライアント証明書の出力パス")
+	gencertClientCmd.Flags().StringVar(&clientOutKey, "out-key", "client.key", "クライアント秘密鍵の出力パス")
+	gencertClientCmd.Flags().IntVar(&clientDays, "days", 365, "有効期間（日数）")
+	gencertClientCmd.Flags().StringVar(&clientCN, "cn", "driensten-client", "Common Name")
+}

--- a/cmd/gencert_server.go
+++ b/cmd/gencert_server.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	serverCACert  string
+	serverCAKey   string
+	serverOutCert string
+	serverOutKey  string
+	serverDays    int
+	serverCN      string
+	serverHosts   []string
+)
+
+var gencertServerCmd = &cobra.Command{
+	Use:   "server",
+	Short: "CAで署名したサーバ証明書と秘密鍵を生成します",
+	Long: `指定したCAで署名したサーバ証明書と秘密鍵を生成します。
+driensten.yaml の HTTP.tls または MQTT.tls に設定して使用します。
+
+SAN（Subject Alternative Name）にはデフォルトで localhost と 127.0.0.1 が含まれます。
+--hosts フラグで追加のホスト名や IP アドレスを指定できます。
+
+使用例:
+  driensten gencert server
+  driensten gencert server --hosts localhost,127.0.0.1,192.168.1.10`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		caCert, caKey, err := loadCACert(serverCACert, serverCAKey)
+		if err != nil {
+			return err
+		}
+
+		key, err := generateECKey()
+		if err != nil {
+			return fmt.Errorf("鍵の生成に失敗: %w", err)
+		}
+
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: serverCN},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().AddDate(0, 0, serverDays),
+			KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		for _, h := range serverHosts {
+			if ip := net.ParseIP(h); ip != nil {
+				template.IPAddresses = append(template.IPAddresses, ip)
+			} else {
+				template.DNSNames = append(template.DNSNames, h)
+			}
+		}
+
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			return fmt.Errorf("証明書の生成に失敗: %w", err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return fmt.Errorf("証明書のパースに失敗: %w", err)
+		}
+
+		keyPEM, err := marshalKeyPEM(key)
+		if err != nil {
+			return fmt.Errorf("秘密鍵のエンコードに失敗: %w", err)
+		}
+		if err := writePEMFile(serverOutCert, marshalCertPEM(cert)); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", serverOutCert, err)
+		}
+		if err := writePEMFile(serverOutKey, keyPEM); err != nil {
+			return fmt.Errorf("%s の書き込みに失敗: %w", serverOutKey, err)
+		}
+
+		fmt.Printf("サーバ証明書: %s\n", serverOutCert)
+		fmt.Printf("サーバ秘密鍵: %s\n", serverOutKey)
+		fmt.Printf("SAN: %v\n", serverHosts)
+		return nil
+	},
+}
+
+func init() {
+	gencertCmd.AddCommand(gencertServerCmd)
+	gencertServerCmd.Flags().StringVar(&serverCACert, "ca-cert", "ca.crt", "CA証明書のパス")
+	gencertServerCmd.Flags().StringVar(&serverCAKey, "ca-key", "ca.key", "CA秘密鍵のパス")
+	gencertServerCmd.Flags().StringVar(&serverOutCert, "out-cert", "server.crt", "サーバ証明書の出力パス")
+	gencertServerCmd.Flags().StringVar(&serverOutKey, "out-key", "server.key", "サーバ秘密鍵の出力パス")
+	gencertServerCmd.Flags().IntVar(&serverDays, "days", 365, "有効期間（日数）")
+	gencertServerCmd.Flags().StringVar(&serverCN, "cn", "driensten-server", "Common Name")
+	gencertServerCmd.Flags().StringSliceVar(&serverHosts, "hosts", []string{"localhost", "127.0.0.1"}, "SANに含めるホスト名またはIPアドレス（カンマ区切り）")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,11 @@ func init() {
 }
 
 // initConfig は、設定ファイルを読み込み、設定されていれば環境変数も読み込みます。
+// gencert サブコマンドは設定ファイルを使用しないためスキップする。
 func initConfig() {
+	if len(os.Args) > 1 && os.Args[1] == "gencert" {
+		return
+	}
 	viper.SetDefault("HTTP.listen", "127.0.0.1:8080")
 	viper.SetDefault("HTTP.root", "dist")
 	viper.SetDefault("HTTP.tls.enable", false)


### PR DESCRIPTION
## Summary

- `driensten gencert ca` — 自己署名ルート CA 証明書と秘密鍵を生成
- `driensten gencert server` — CA 署名済みサーバ証明書を生成（SAN: `localhost`, `127.0.0.1`）
- `driensten gencert client` — CA 署名済みクライアント証明書を生成（MQTT `auth.mode=cert` 用）

## 背景

TLS の動作確認（HTTP TLS・MQTT TLS トランスポート・MQTT クライアント証明書認証）に必要な証明書を、外部ツールなしに CLI から生成できるようにした。

## 変更内容

| ファイル | 変更 |
|---|---|
| `cmd/gencert.go` | 親コマンド `gencert` と共通ヘルパー関数（鍵生成・PEMエンコード・CA読み込み） |
| `cmd/gencert_ca.go` | `gencert ca` サブコマンド |
| `cmd/gencert_server.go` | `gencert server` サブコマンド（`--hosts` フラグで SAN をカスタマイズ可能） |
| `cmd/gencert_client.go` | `gencert client` サブコマンド |
| `cmd/root.go` | `gencert` 実行時は `driensten.yaml` が不要なため `initConfig` をスキップ |

## 共通フラグ

| フラグ | 説明 | デフォルト |
|---|---|---|
| `--out-cert` | 証明書の出力パス | コマンド依存 |
| `--out-key` | 秘密鍵の出力パス | コマンド依存 |
| `--ca-cert` | CA 証明書パス（server/client） | `ca.crt` |
| `--ca-key` | CA 秘密鍵パス（server/client） | `ca.key` |
| `--days` | 有効期間（日数） | `365` |
| `--cn` | Common Name | コマンド依存 |
| `--hosts` | SAN ホスト名/IP（server のみ） | `localhost,127.0.0.1` |

## 典型的な使用フロー

```sh
driensten gencert ca
driensten gencert server
driensten gencert client
```

その後 `driensten.yaml` に以下を設定:

```yaml
MQTT:
  tls:
    enable: true
    cert: server.crt
    key: server.key
    client_ca: ca.crt  # cert 認証モード時のみ
```

## 技術仕様

- アルゴリズム: ECDSA P-256
- 出力形式: PEM（ファイルパーミッション `0600`）
- サーバ証明書: `ExtKeyUsageServerAuth` + SAN（IP/DNS 自動判別）
- クライアント証明書: `ExtKeyUsageClientAuth`

## Test plan

- [ ] `driensten gencert ca` で `ca.crt` / `ca.key` が生成される
- [ ] `driensten gencert server` で `server.crt` / `server.key` が生成され、CA で検証できる
- [ ] `driensten gencert client` で `client.crt` / `client.key` が生成され、CA で検証できる
- [ ] `driensten run` が設定ファイルなし環境で gencert を実行しても影響を受けない
- [ ] `openssl verify -CAfile ca.crt server.crt` → OK
- [ ] `openssl verify -CAfile ca.crt client.crt` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)