### PR TITLE
feat: gencert client に --format pkcs12 オプションを追加

### DIFF
--- a/cmd/gencert_client.go
+++ b/cmd/gencert_client.go
@@ -16,23 +16,29 @@ limitations under the License.
 package cmd
 
 import (
+	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 var (
-	clientCACert  string
-	clientCAKey   string
-	clientOutCert string
-	clientOutKey  string
-	clientDays    int
-	clientCN      string
+	clientCACert         string
+	clientCAKey          string
+	clientOutCert        string
+	clientOutKey         string
+	clientOutP12         string
+	clientDays           int
+	clientCN             string
+	clientFormat         string
+	clientPKCS12Password string
 )
 
 var gencertClientCmd = &cobra.Command{
@@ -46,8 +52,13 @@ driensten.yaml の MQTT.tls.client_ca に CA 証明書のパスを設定し、
 
 使用例:
   driensten gencert client
-  driensten gencert client --cn my-device --out-cert device.crt --out-key device.key`,
+  driensten gencert client --cn my-device --out-cert device.crt --out-key device.key
+  driensten gencert client --format pkcs12 --pkcs12-password secret --out-p12 device.p12`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if clientFormat != "pem" && clientFormat != "pkcs12" {
+			return fmt.Errorf("不正なフォーマット: %q (pem または pkcs12 を指定してください)", clientFormat)
+		}
+
 		caCert, caKey, err := loadCACert(clientCACert, clientCAKey)
 		if err != nil {
 			return err
@@ -76,29 +87,50 @@ driensten.yaml の MQTT.tls.client_ca に CA 証明書のパスを設定し、
 			return fmt.Errorf("証明書のパースに失敗: %w", err)
 		}
 
-		keyPEM, err := marshalKeyPEM(key)
-		if err != nil {
-			return fmt.Errorf("秘密鍵のエンコードに失敗: %w", err)
+		if clientFormat == "pkcs12" {
+			return writeClientPKCS12(cert, key, caCert)
 		}
-		if err := writePEMFile(clientOutCert, marshalCertPEM(cert)); err != nil {
-			return fmt.Errorf("%s の書き込みに失敗: %w", clientOutCert, err)
-		}
-		if err := writePEMFile(clientOutKey, keyPEM); err != nil {
-			return fmt.Errorf("%s の書き込みに失敗: %w", clientOutKey, err)
-		}
-
-		fmt.Printf("クライアント証明書: %s\n", clientOutCert)
-		fmt.Printf("クライアント秘密鍵: %s\n", clientOutKey)
-		return nil
+		return writeClientPEM(cert, key)
 	},
+}
+
+func writeClientPEM(cert *x509.Certificate, key *ecdsa.PrivateKey) error {
+	keyPEM, err := marshalKeyPEM(key)
+	if err != nil {
+		return fmt.Errorf("秘密鍵のエンコードに失敗: %w", err)
+	}
+	if err := writePEMFile(clientOutCert, marshalCertPEM(cert)); err != nil {
+		return fmt.Errorf("%s の書き込みに失敗: %w", clientOutCert, err)
+	}
+	if err := writePEMFile(clientOutKey, keyPEM); err != nil {
+		return fmt.Errorf("%s の書き込みに失敗: %w", clientOutKey, err)
+	}
+	fmt.Printf("クライアント証明書: %s\n", clientOutCert)
+	fmt.Printf("クライアント秘密鍵: %s\n", clientOutKey)
+	return nil
+}
+
+func writeClientPKCS12(cert *x509.Certificate, key *ecdsa.PrivateKey, caCert *x509.Certificate) error {
+	pfxData, err := pkcs12.Encode(rand.Reader, key, cert, []*x509.Certificate{caCert}, clientPKCS12Password)
+	if err != nil {
+		return fmt.Errorf("PKCS#12の生成に失敗: %w", err)
+	}
+	if err := os.WriteFile(clientOutP12, pfxData, 0o600); err != nil {
+		return fmt.Errorf("%s の書き込みに失敗: %w", clientOutP12, err)
+	}
+	fmt.Printf("クライアント証明書 (PKCS#12): %s\n", clientOutP12)
+	return nil
 }
 
 func init() {
 	gencertCmd.AddCommand(gencertClientCmd)
 	gencertClientCmd.Flags().StringVar(&clientCACert, "ca-cert", "ca.crt", "CA証明書のパス")
 	gencertClientCmd.Flags().StringVar(&clientCAKey, "ca-key", "ca.key", "CA秘密鍵のパス")
-	gencertClientCmd.Flags().StringVar(&clientOutCert, "out-cert", "client.crt", "クライアント証明書の出力パス")
-	gencertClientCmd.Flags().StringVar(&clientOutKey, "out-key", "client.key", "クライアント秘密鍵の出力パス")
+	gencertClientCmd.Flags().StringVar(&clientFormat, "format", "pem", "出力フォーマット (pem または pkcs12)")
+	gencertClientCmd.Flags().StringVar(&clientOutCert, "out-cert", "client.crt", "クライアント証明書の出力パス (pem フォーマット用)")
+	gencertClientCmd.Flags().StringVar(&clientOutKey, "out-key", "client.key", "クライアント秘密鍵の出力パス (pem フォーマット用)")
+	gencertClientCmd.Flags().StringVar(&clientOutP12, "out-p12", "client.p12", "PKCS#12ファイルの出力パス (pkcs12 フォーマット用)")
+	gencertClientCmd.Flags().StringVar(&clientPKCS12Password, "pkcs12-password", "", "PKCS#12ファイルのパスワード (pkcs12 フォーマット用)")
 	gencertClientCmd.Flags().IntVar(&clientDays, "days", 365, "有効期間（日数）")
 	gencertClientCmd.Flags().StringVar(&clientCN, "cn", "driensten-client", "Common Name")
 }

--- a/cmd/gencert_client_test.go
+++ b/cmd/gencert_client_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright © 2026 ramsesyok
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// setupTestCA creates a self-signed CA cert and key in dir, returns their paths.
+func setupTestCA(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "ca.crt")
+	keyPath = filepath.Join(dir, "ca.key")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	return certPath, keyPath
+}
+
+func TestGencertClientPEM(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := setupTestCA(t, dir)
+
+	outCert := filepath.Join(dir, "client.crt")
+	outKey := filepath.Join(dir, "client.key")
+
+	clientCACert = caCert
+	clientCAKey = caKey
+	clientOutCert = outCert
+	clientOutKey = outKey
+	clientOutP12 = filepath.Join(dir, "client.p12")
+	clientDays = 1
+	clientCN = "test-client"
+	clientFormat = "pem"
+	clientPKCS12Password = ""
+
+	err := gencertClientCmd.RunE(gencertClientCmd, nil)
+	require.NoError(t, err)
+
+	certData, err := os.ReadFile(outCert)
+	require.NoError(t, err)
+	block, _ := pem.Decode(certData)
+	require.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.Equal(t, "test-client", cert.Subject.CommonName)
+
+	keyData, err := os.ReadFile(outKey)
+	require.NoError(t, err)
+	keyBlock, _ := pem.Decode(keyData)
+	require.NotNil(t, keyBlock)
+	_, err = x509.ParseECPrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+}
+
+func TestGencertClientPKCS12(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := setupTestCA(t, dir)
+
+	outP12 := filepath.Join(dir, "client.p12")
+	password := "testpassword"
+
+	clientCACert = caCert
+	clientCAKey = caKey
+	clientOutCert = filepath.Join(dir, "client.crt")
+	clientOutKey = filepath.Join(dir, "client.key")
+	clientOutP12 = outP12
+	clientDays = 1
+	clientCN = "test-client-p12"
+	clientFormat = "pkcs12"
+	clientPKCS12Password = password
+
+	err := gencertClientCmd.RunE(gencertClientCmd, nil)
+	require.NoError(t, err)
+
+	p12Data, err := os.ReadFile(outP12)
+	require.NoError(t, err)
+
+	key, cert, _, err := pkcs12.DecodeChain(p12Data, password)
+	require.NoError(t, err)
+	assert.Equal(t, "test-client-p12", cert.Subject.CommonName)
+	_, ok := key.(*ecdsa.PrivateKey)
+	assert.True(t, ok)
+}
+
+func TestGencertClientPKCS12EmptyPassword(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := setupTestCA(t, dir)
+
+	outP12 := filepath.Join(dir, "client.p12")
+
+	clientCACert = caCert
+	clientCAKey = caKey
+	clientOutCert = filepath.Join(dir, "client.crt")
+	clientOutKey = filepath.Join(dir, "client.key")
+	clientOutP12 = outP12
+	clientDays = 1
+	clientCN = "test-client-nopass"
+	clientFormat = "pkcs12"
+	clientPKCS12Password = ""
+
+	err := gencertClientCmd.RunE(gencertClientCmd, nil)
+	require.NoError(t, err)
+
+	p12Data, err := os.ReadFile(outP12)
+	require.NoError(t, err)
+
+	_, cert, _, err := pkcs12.DecodeChain(p12Data, "")
+	require.NoError(t, err)
+	assert.Equal(t, "test-client-nopass", cert.Subject.CommonName)
+}
+
+func TestGencertClientInvalidFormat(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := setupTestCA(t, dir)
+
+	clientCACert = caCert
+	clientCAKey = caKey
+	clientFormat = "invalid"
+
+	err := gencertClientCmd.RunE(gencertClientCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "不正なフォーマット")
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.50.0
 )
 
 require (
@@ -31,7 +32,6 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
@@ -39,4 +39,5 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.7.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -80,3 +80,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.7.1 h1:bxkUPRsvTPNRBZa4M/aSX4PyMOEbq3V8I6hbkG4F4Q8=
+software.sslmate.com/src/go-pkcs12 v0.7.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=


### PR DESCRIPTION
## 概要

Java / .NET クライアント向けに、`gencert client` サブコマンドで PKCS#12 形式（`.p12` / `.pfx`）のクライアント証明書を出力できるようにする。

## 変更内容

- `--format` フラグを追加（`pem`（デフォルト） / `pkcs12`）
- `--out-p12` フラグを追加（デフォルト: `client.p12`）
- `--pkcs12-password` フラグを追加（空文字も可）
- `software.sslmate.com/src/go-pkcs12 v0.7.1` を依存関係に追加
  - `golang.org/x/crypto/pkcs12` はデコード専用でフリーズ済みのため、エンコード対応の本パッケージを採用

## フラグ設計

| フォーマット | 使用フラグ | 出力ファイル |
|---|---|---|
| `pem`（デフォルト） | `--out-cert`, `--out-key` | `client.crt` + `client.key` |
| `pkcs12` | `--out-p12`, `--pkcs12-password` | `client.p12`（証明書・鍵・CA証明書を1ファイルに格納） |

## 使用例

```bash
# Java / .NET 向け PKCS#12 出力
driensten gencert client --format pkcs12 --pkcs12-password secret --out-p12 device.p12
```

## テスト

- PEM フォーマット出力テスト
- PKCS#12 パスワードあり出力テスト
- PKCS#12 パスワードなし出力テスト
- 不正フォーマット指定のエラーテスト

## レビュアーへの補足

- PKCS#12 ファイルには CA 証明書チェーンも含めているため、Java の `KeyStore.load()` や .NET の `X509Certificate2` でそのまま利用可能
- パスワードは空文字を許容（ツール内部用途での簡易利用を想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)